### PR TITLE
feat: Rewrite gc to support conventional commits

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -29,5 +29,3 @@ source "$DOTFILES_DIR/zsh/sandbox.sh"
 
 autoload -U +X bashcompinit && bashcompinit
 complete -o nospace -C /usr/local/bin/terraform terraform
-
-[ -f "$HOME/.fzf.zsh" ] && source "$HOME/.fzf.zsh"

--- a/zsh/aliases/git/aliases.sh
+++ b/zsh/aliases/git/aliases.sh
@@ -9,16 +9,18 @@ commit_with_issue_tag() {
   templatePath="$(git rev-parse --show-toplevel)/.git/.gitmessagetemplate"
   remote=$(git remote get-url origin)
 
+  # For github ids `#` character is required at the beginning
+  task_id_prefix=""
+  if [[ "$taskId" =~ ^[0-9] ]]; then
+    task_id_prefix="#"
+  fi
+
   if [[ -z "$taskId" ]]; then
     git commit "$@"
+  elif [[ $remote == *"github"* || $remote == *"azure"* ]]; then
+    printf "feat:\n\nCloses %s" "$task_id_prefix$taskId" >"$templatePath" && git commit -t "$templatePath" "$@"
   else
-    if [[ $remote == *"bitbucket"* ]]; then
-      echo -n "[$taskId] " >"$templatePath" && git commit -t "$templatePath" "$@"
-    elif [[ $remote == *"github"* || $remote == *"azure"* ]]; then
-      echo -n "(#$taskId) " >"$templatePath" && git commit -t "$templatePath" "$@"
-    else
-      git commit "$@"
-    fi
+    git commit "$@"
   fi
 }
 

--- a/zsh/misc.sh
+++ b/zsh/misc.sh
@@ -8,7 +8,7 @@ export SSH_AUTH_SOCK
 gpgconf --launch gpg-agent
 
 # Powerline install
-. /usr/local/lib/python3.9/site-packages/powerline/bindings/zsh/powerline.zsh
+source /usr/local/lib/python3.9/site-packages/powerline/bindings/zsh/powerline.zsh
 
 # NVM
 source "$DOTFILES_DIR/zsh/nvm.sh"

--- a/zsh/nvm.sh
+++ b/zsh/nvm.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env zsh
 
 export NVM_DIR="$HOME/.nvm"
 
 # Should not follow nvm script
 # shellcheck disable=1091
-. "/usr/local/opt/nvm/nvm.sh" # This loads nvm
+source "/usr/local/opt/nvm/nvm.sh" # This loads nvm

--- a/zsh/paths.sh
+++ b/zsh/paths.sh
@@ -30,7 +30,6 @@ PATH="$HOME/.cargo/bin:$PATH"
 PATH="$JAVA_HOME/bin:$PATH"
 export PATH
 
-export NVM_DIR=~/.nvm
 export XML_CATALOG_FILES="/usr/local/etc/xml/catalog"
 
 GOPATH=$(go env GOPATH)


### PR DESCRIPTION
Adds new template to alias `gc` to be similar to the format of
conventional commits.

Cleanup script of duplicates

Closes #9