### PR TITLE
fix: Colors of zsh-autosuggest and vim

### DIFF
--- a/alacritty/alacritty.yml
+++ b/alacritty/alacritty.yml
@@ -1,33 +1,40 @@
 ---
 # Colors (Solarized Dark)
+# yamllint disable-line rule:line-length
+# Taken from: https://github.com/rajasegar/alacritty-themes/blob/master/themes/Solarized-Dark.yml
 schemes:
     solarized_dark: &solarized_dark
         # Default colors
         primary:
-            background: '0x002b36'
-            foreground: '0x839496'
+            background: '#002b36'
+            foreground: '#839496'
+
+        # Cursor colors
+        cursor:
+            text: '#002b36'
+            cursor: '#839496'
 
         # Normal colors
         normal:
-            black: '0x073642'
-            red: '0xdc322f'
-            green: '0x859900'
-            yellow: '0xb58900'
-            blue: '0x268bd2'
-            magenta: '0xd33682'
-            cyan: '0x2aa198'
-            white: '0xeee8d5'
+            black: '#073642'
+            red: '#dc322f'
+            green: '#859900'
+            yellow: '#b58900'
+            blue: '#268bd2'
+            magenta: '#d33682'
+            cyan: '#2aa198'
+            white: '#eee8d5'
 
         # Bright colors
         bright:
-            black: '0x002b36'
-            red: '0xcb4b16'
-            green: '0x586e75'
-            yellow: '0x657b83'
-            blue: '0x839496'
-            magenta: '0x6c71c4'
-            cyan: '0x93a1a1'
-            white: '0xfdf6e3'
+            black: '#586e75'
+            red: '#cb4b16'
+            green: '#586e75'
+            yellow: '#657b83'
+            blue: '#839496'
+            magenta: '#6c71c4'
+            cyan: '#93a1a1'
+            white: '#fdf6e3'
 window:
     startup_mode: SimpleFullscreen
 

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -4,6 +4,10 @@ set -g prefix C-a
 unbind-key C-b
 bind-key C-a send-prefix
 
+# Enable RGB colour if running in xterm(1)
+set -g default-terminal "xterm-256color"
+set -ga terminal-overrides ",*256col*:Tc"
+
 # split panes using | and -
 bind - split-window -v
 bind | split-window -h

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -26,7 +26,7 @@ Plugin 'VundleVim/Vundle.vim'
 " Plugins list
 Plugin 'neoclide/coc.nvim', {'branch': 'release'}
 Plugin 'wincent/terminus'
-Plugin 'altercation/vim-colors-solarized'
+Plugin 'lifepillar/vim-solarized8'
 Plugin 'bling/vim-airline'
 Plugin 'vim-airline/vim-airline-themes'
 Plugin 'ctrlpvim/ctrlp.vim'
@@ -51,8 +51,10 @@ filetype plugin indent on
 
 " Vim colors
 syntax on
+set termguicolors
 set background=dark
-colorscheme solarized
+colorscheme solarized8
+autocmd vimenter * ++nested colorscheme solarized8
 
 " SETTINGS
 set encoding=utf-8


### PR DESCRIPTION
Applies True color fixes in .tmux.conf.

Changes the palette in Alacritty.

Changes vim theme to faster solarized8.

Closes #22